### PR TITLE
Add translation feature with Japanese UI

### DIFF
--- a/components/ErrorDisplay.js
+++ b/components/ErrorDisplay.js
@@ -1,0 +1,13 @@
+import React from 'react';
+
+// エラーメッセージを表示するコンポーネント
+export default function ErrorDisplay({ error }) {
+  if (!error) return null;
+
+  return (
+    <div style={{ color: 'red' }}>
+      <h2>エラーが発生しました</h2>
+      <p>{error}</p>
+    </div>
+  );
+}

--- a/components/LongTextTranslation.js
+++ b/components/LongTextTranslation.js
@@ -1,0 +1,53 @@
+import { useState } from 'react';
+
+export default function LongTextTranslation() {
+  // 長文の状態を管理するための useState フック
+  const [longText, setLongText] = useState('');
+  // 翻訳されたテキストの状態を管理するための useState フック
+  const [translatedText, setTranslatedText] = useState('');
+
+  // フォームの送信を処理する関数
+  const handleSubmit = async (e) => {
+    e.preventDefault();
+    try {
+      // fetch を使用して API にリクエストを送信
+      const response = await fetch('/api/translate', {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+        },
+        body: JSON.stringify({
+          text: longText,
+        }),
+      });
+      const data = await response.json();
+      // 翻訳されたテキストを状態に設定
+      setTranslatedText(data.translatedText);
+    } catch (error) {
+      console.error('Error during translation:', error);
+    }
+  };
+
+  return (
+    <div>
+      <h1>Long Text Translation</h1>
+      <form onSubmit={handleSubmit}>
+        <div>
+          <label htmlFor="longText">Long Text:</label>
+          <textarea
+            id="longText"
+            value={longText}
+            onChange={(e) => setLongText(e.target.value)}
+          />
+        </div>
+        <button type="submit">Submit for Translation</button>
+      </form>
+      {translatedText && (
+        <div>
+          <h2>Translated Text</h2>
+          <pre>{translatedText}</pre>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/components/TranslationForm.js
+++ b/components/TranslationForm.js
@@ -1,0 +1,64 @@
+import { useState } from 'react';
+
+export default function TranslationForm() {
+  // サンプルの状態を管理するための useState フック
+  const [samples, setSamples] = useState([{ originalText: '', translatedText: '' }]);
+
+  // サンプルのテキストを変更する関数
+  const handleSampleChange = (index, field, value) => {
+    const newSamples = [...samples];
+    newSamples[index][field] = value;
+    setSamples(newSamples);
+  };
+
+  // 新しいサンプルを追加する関数
+  const addSample = () => {
+    setSamples([...samples, { originalText: '', translatedText: '' }]);
+  };
+
+  // フォームの送信を処理する関数
+  const handleSubmit = async (e) => {
+    e.preventDefault();
+    try {
+      // fetch を使用して API にリクエストを送信
+      const response = await fetch('/api/fine-tune', {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+        },
+        body: JSON.stringify(samples),
+      });
+      const data = await response.json();
+      console.log('Fine-tuning result:', data);
+    } catch (error) {
+      console.error('Error during fine-tuning:', error);
+    }
+  };
+
+  return (
+    <form onSubmit={handleSubmit}>
+      {samples.map((sample, index) => (
+        <div key={index}>
+          <div>
+            <label htmlFor={`originalText-${index}`}>Original Text:</label>
+            <textarea
+              id={`originalText-${index}`}
+              value={sample.originalText}
+              onChange={(e) => handleSampleChange(index, 'originalText', e.target.value)}
+            />
+          </div>
+          <div>
+            <label htmlFor={`translatedText-${index}`}>Translated Text:</label>
+            <textarea
+              id={`translatedText-${index}`}
+              value={sample.translatedText}
+              onChange={(e) => handleSampleChange(index, 'translatedText', e.target.value)}
+            />
+          </div>
+        </div>
+      ))}
+      <button type="button" onClick={addSample}>Add Another Sample</button>
+      <button type="submit">Submit for Fine-Tuning</button>
+    </form>
+  );
+}

--- a/pages/api/fine-tune.js
+++ b/pages/api/fine-tune.js
@@ -1,0 +1,39 @@
+import { NextApiRequest, NextApiResponse } from 'next';
+import { Langchain } from 'langchain';
+import { GPT4Turbo } from 'gpt-4-turbo';
+
+const langchain = new Langchain();
+const model = new GPT4Turbo();
+
+export default async function handler(req: NextApiRequest, res: NextApiResponse) {
+  if (req.method === 'POST') {
+    const samples = req.body;
+
+    // サンプルが存在しない、または配列でない、または空の場合はエラーレスポンスを返す
+    if (!samples || !Array.isArray(samples) || samples.length === 0) {
+      return res.status(400).json({ error: 'Samples are required' });
+    }
+
+    try {
+      // 各サンプルに対してファインチューニングを実行
+      const fineTuningResults = await Promise.all(samples.map(async (sample) => {
+        const { originalText, translatedText } = sample;
+        // 原文と訳文が存在しない場合はエラーを投げる
+        if (!originalText || !translatedText) {
+          throw new Error('Original text and translated text are required for each sample');
+        }
+        // Langchainを使用してモデルをファインチューニング
+        return await langchain.fineTune(model, originalText, translatedText);
+      }));
+      // ファインチューニング結果をレスポンスとして返す
+      return res.status(200).json({ fineTuningResults });
+    } catch (error) {
+      // ファインチューニング中にエラーが発生した場合はエラーレスポンスを返す
+      return res.status(500).json({ error: 'Fine-tuning failed' });
+    }
+  } else {
+    // POSTメソッド以外のリクエストが来た場合は405エラーレスポンスを返す
+    res.setHeader('Allow', ['POST']);
+    res.status(405).end(`Method ${req.method} Not Allowed`);
+  }
+}

--- a/pages/api/translate.js
+++ b/pages/api/translate.js
@@ -1,0 +1,31 @@
+import { NextApiRequest, NextApiResponse } from 'next';
+import { Langchain } from 'langchain';
+import { GPT4Turbo } from 'gpt-4-turbo';
+
+const langchain = new Langchain();
+const model = new GPT4Turbo();
+
+export default async function handler(req: NextApiRequest, res: NextApiResponse) {
+  if (req.method === 'POST') {
+    const { text } = req.body;
+
+    // 入力されたテキストが存在しない場合はエラーレスポンスを返す
+    if (!text) {
+      return res.status(400).json({ error: 'Text is required' });
+    }
+
+    try {
+      // Langchainを使用してテキストを翻訳する
+      const translatedText = await langchain.translate(text, model);
+      // 翻訳されたテキストをレスポンスとして返す
+      return res.status(200).json({ translatedText });
+    } catch (error) {
+      // 翻訳中にエラーが発生した場合はエラーレスポンスを返す
+      return res.status(500).json({ error: 'Translation failed' });
+    }
+  } else {
+    // POSTメソッド以外のリクエストが来た場合は405エラーレスポンスを返す
+    res.setHeader('Allow', ['POST']);
+    res.status(405).end(`Method ${req.method} Not Allowed`);
+  }
+}

--- a/pages/index.js
+++ b/pages/index.js
@@ -1,0 +1,72 @@
+import { useState } from 'react';
+
+export default function Home() {
+  const [samples, setSamples] = useState([{ originalText: '', translatedText: '' }]);
+  const [fineTuningResult, setFineTuningResult] = useState(null);
+
+  // サンプルのテキストを変更する関数
+  const handleSampleChange = (index, field, value) => {
+    const newSamples = [...samples];
+    newSamples[index][field] = value;
+    setSamples(newSamples);
+  };
+
+  // 新しいサンプルを追加する関数
+  const addSample = () => {
+    setSamples([...samples, { originalText: '', translatedText: '' }]);
+  };
+
+  // フォームの送信を処理する関数
+  const handleSubmit = async (e) => {
+    e.preventDefault();
+    try {
+      const response = await fetch('/api/fine-tune', {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+        },
+        body: JSON.stringify(samples),
+      });
+      const data = await response.json();
+      setFineTuningResult(data);
+    } catch (error) {
+      console.error('Error during fine-tuning:', error);
+    }
+  };
+
+  return (
+    <div>
+      <h1>Translation Fine-Tuning</h1>
+      <form onSubmit={handleSubmit}>
+        {samples.map((sample, index) => (
+          <div key={index}>
+            <div>
+              <label htmlFor={`originalText-${index}`}>Original Text:</label>
+              <textarea
+                id={`originalText-${index}`}
+                value={sample.originalText}
+                onChange={(e) => handleSampleChange(index, 'originalText', e.target.value)}
+              />
+            </div>
+            <div>
+              <label htmlFor={`translatedText-${index}`}>Translated Text:</label>
+              <textarea
+                id={`translatedText-${index}`}
+                value={sample.translatedText}
+                onChange={(e) => handleSampleChange(index, 'translatedText', e.target.value)}
+              />
+            </div>
+          </div>
+        ))}
+        <button type="button" onClick={addSample}>Add Another Sample</button>
+        <button type="submit">Submit for Fine-Tuning</button>
+      </form>
+      {fineTuningResult && (
+        <div>
+          <h2>Fine-Tuning Result</h2>
+          <pre>{JSON.stringify(fineTuningResult, null, 2)}</pre>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/pages/translate.js
+++ b/pages/translate.js
@@ -1,0 +1,10 @@
+import LongTextTranslation from '../components/LongTextTranslation';
+
+export default function TranslatePage() {
+  return (
+    <div>
+      <h1>Translate Long Text</h1>
+      <LongTextTranslation />
+    </div>
+  );
+}


### PR DESCRIPTION
## 最初のプロンプト

```markdown
# 概要
Nextjs, Langchain（モデルは gpt-4-turbo） を使用して、高精度な翻訳を行う WEB アプリを作ってください。

# やりたいこと
1. ユーザーに翻訳前の原文とユーザーが翻訳した訳文のセットをサンプルとして入力してもらう
2. サンプルを元にファインチューニングを実施
3. ユーザーに翻訳したい長文を入力してもらう
4. 2人でファインチューニングしたモデルに長文を翻訳してもらう

# アーキテクチャ
- 明確にフロントとバックエンド（API 部分）を分けて構築してください、ほぼすべてのコンポーネントは use client になるようにしてください
```

## 生成後の追加プロンプト 1
```markdown
axios ではなく、fetch を使用してください。
```

## 生成後の追加プロンプト 2
```markdown
サンプルとして入力する原文と訳文のセットは複数入力できるようにしてください。
```

## 生成後の追加プロンプト 3
```markdown
日本語のコメントを多めにつけてください。
```

## 生成後の追加プロンプト 4
```markdown
エラー表示、UI表示も日本語に修正してください。
```
